### PR TITLE
Disable coverage options when not using coverage.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,11 +7,11 @@ module.exports = function (config) {
     basePath: 'public',
     browsers: [process.env.TRAVIS ? 'Chrome_travis_ci' : 'Chrome'],
     files: ['scripts/modules.js', 'scripts/test.js'],
-    reporters: ['dots', 'coverage'],
+    reporters: ['dots'].concat(process.env.COVERAGE ? ['coverage'] : []),
     frameworks: ['mocha'],
     preprocessors: {
       '**/*.js': ['sourcemap'],
-      'scripts/modules.js': ['coverage']
+      'scripts/modules.js': process.env.COVERAGE ? ['coverage'] : []
     },
     coverageReporter: {
       type: 'json',

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint app/scripts/**/*.js test/*.js",
     "test": "karma start --single-run",
-    "coverage": "npm test && npm run remap-coverage && npm run coverage-report",
+    "coverage": "COVERAGE=true npm test && npm run remap-coverage && npm run coverage-report",
     "remap-coverage": "remap-istanbul -i coverage/coverage-unmapped.json -o coverage/coverage-remapped.json",
     "coverage-report": "./coverage-report.js"
   },


### PR DESCRIPTION
This should speed up the tests and also make them possible to debug.